### PR TITLE
Add PR gate workflow

### DIFF
--- a/.github/workflows/macaron-check-github-actions.yml
+++ b/.github/workflows/macaron-check-github-actions.yml
@@ -34,4 +34,4 @@ jobs:
         with:
           repo_path: ./
           policy_file: check-github-actions
-          policy_purl: pkg:github.com/oracle/cluster-api-provider-oci@.*
+          policy_purl: pkg:github.com/${{ github.repository }}@.*

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -210,7 +210,6 @@ jobs:
       pull-requests: read
     steps:
       - name: Upsert PR gate comment
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -219,6 +218,8 @@ jobs:
         run: |
           marker='<!-- capoci-pr-gate-report -->'
           body_file="${RUNNER_TEMP}/pr-gate-comment.md"
+          comments_file="${RUNNER_TEMP}/pr-gate-comments.json"
+          error_file="${RUNNER_TEMP}/pr-gate-comment.error"
           payload_file="${RUNNER_TEMP}/pr-gate-comment.json"
 
           {
@@ -234,14 +235,20 @@ jobs:
 
           jq -n --rawfile body "${body_file}" '{body: $body}' > "${payload_file}"
 
-          comment_id="$(
-            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-              --jq '.[] | select(.body | startswith("<!-- capoci-pr-gate-report -->")) | .id' |
-              head -n 1
-          )"
+          if ! gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" > "${comments_file}" 2> "${error_file}"; then
+            echo "::notice::Skipping PR gate comment because existing comments could not be listed."
+            cat "${error_file}"
+            exit 0
+          fi
+
+          comment_id="$(jq -r '.[] | select(.body | startswith("<!-- capoci-pr-gate-report -->")) | .id' "${comments_file}" | head -n 1)"
 
           if [ -n "${comment_id}" ]; then
-            gh api --method PATCH "repos/${REPO}/issues/comments/${comment_id}" --input "${payload_file}"
+            if ! gh api --method PATCH "repos/${REPO}/issues/comments/${comment_id}" --input "${payload_file}"; then
+              echo "::notice::Skipping PR gate comment update because the GitHub API rejected the request."
+            fi
           else
-            gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input "${payload_file}"
+            if ! gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input "${payload_file}"; then
+              echo "::notice::Skipping PR gate comment creation because the GitHub API rejected the request."
+            fi
           fi

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -50,8 +50,8 @@ jobs:
       - name: Run make build
         run: |
           set +e
-          make build > .pr-gate/make-build.log 2>&1
-          status=$?
+          make build 2>&1 | tee .pr-gate/make-build.log
+          status=${PIPESTATUS[0]}
           if [ "${status}" -eq 0 ]; then
             printf 'make build\tPASS\tBuild completed\n' >> .pr-gate/results.tsv
           else
@@ -65,8 +65,8 @@ jobs:
       - name: Run make test
         run: |
           set +e
-          make test > .pr-gate/make-test.log 2>&1
-          status=$?
+          make test 2>&1 | tee .pr-gate/make-test.log
+          status=${PIPESTATUS[0]}
           if [ "${status}" -eq 0 ]; then
             printf 'make test\tPASS\tUnit tests completed\n' >> .pr-gate/results.tsv
           else
@@ -81,11 +81,11 @@ jobs:
         run: |
           set +e
 
-          make generate > .pr-gate/make-generate.log 2>&1
-          generate_status=$?
+          make generate 2>&1 | tee .pr-gate/make-generate.log
+          generate_status=${PIPESTATUS[0]}
 
-          make manifests > .pr-gate/make-manifests.log 2>&1
-          manifests_status=$?
+          make manifests 2>&1 | tee .pr-gate/make-manifests.log
+          manifests_status=${PIPESTATUS[0]}
 
           if [ "${generate_status}" -ne 0 ]; then
             touch .pr-gate/failed
@@ -131,8 +131,8 @@ jobs:
         run: |
           set +e
 
-          make generate-e2e-templates > .pr-gate/make-generate-e2e-templates.log 2>&1
-          template_status=$?
+          make generate-e2e-templates 2>&1 | tee .pr-gate/make-generate-e2e-templates.log
+          template_status=${PIPESTATUS[0]}
 
           if [ "${template_status}" -ne 0 ]; then
             touch .pr-gate/failed

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -1,0 +1,247 @@
+name: PR Gate
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+
+# Additional local-only checks considered but not enforced by this first gate:
+# - make lint
+# - go mod tidy followed by git diff --exit-code -- go.mod go.sum
+# - make build-book for docs/book changes
+
+concurrency:
+  group: pr-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  local-checks:
+    name: Local checks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      report: ${{ steps.final-report.outputs.report }}
+      result: ${{ steps.final-report.outputs.result }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.24.3"
+          cache: true
+
+      - name: Initialize report
+        run: |
+          mkdir -p .pr-gate
+          printf 'Check\tResult\tDetails\n' > .pr-gate/results.tsv
+
+      - name: Run make build
+        run: |
+          set +e
+          make build > .pr-gate/make-build.log 2>&1
+          status=$?
+          if [ "${status}" -eq 0 ]; then
+            printf 'make build\tPASS\tBuild completed\n' >> .pr-gate/results.tsv
+          else
+            touch .pr-gate/failed
+            printf 'make build\tFAIL\tExit code %s\n' "${status}" >> .pr-gate/results.tsv
+            echo "::group::make build output"
+            tail -n 120 .pr-gate/make-build.log
+            echo "::endgroup::"
+          fi
+
+      - name: Run make test
+        run: |
+          set +e
+          make test > .pr-gate/make-test.log 2>&1
+          status=$?
+          if [ "${status}" -eq 0 ]; then
+            printf 'make test\tPASS\tUnit tests completed\n' >> .pr-gate/results.tsv
+          else
+            touch .pr-gate/failed
+            printf 'make test\tFAIL\tExit code %s\n' "${status}" >> .pr-gate/results.tsv
+            echo "::group::make test output"
+            tail -n 120 .pr-gate/make-test.log
+            echo "::endgroup::"
+          fi
+
+      - name: Check generated API and manifests
+        run: |
+          set +e
+
+          make generate > .pr-gate/make-generate.log 2>&1
+          generate_status=$?
+
+          make manifests > .pr-gate/make-manifests.log 2>&1
+          manifests_status=$?
+
+          if [ "${generate_status}" -ne 0 ]; then
+            touch .pr-gate/failed
+            printf 'make generate\tFAIL\tExit code %s\n' "${generate_status}" >> .pr-gate/results.tsv
+            echo "::group::make generate output"
+            tail -n 120 .pr-gate/make-generate.log
+            echo "::endgroup::"
+          else
+            printf 'make generate\tPASS\tGenerated code completed\n' >> .pr-gate/results.tsv
+          fi
+
+          if [ "${manifests_status}" -ne 0 ]; then
+            touch .pr-gate/failed
+            printf 'make manifests\tFAIL\tExit code %s\n' "${manifests_status}" >> .pr-gate/results.tsv
+            echo "::group::make manifests output"
+            tail -n 120 .pr-gate/make-manifests.log
+            echo "::endgroup::"
+          else
+            printf 'make manifests\tPASS\tManifest generation completed\n' >> .pr-gate/results.tsv
+          fi
+
+          if [ "${generate_status}" -eq 0 ] && [ "${manifests_status}" -eq 0 ]; then
+            git diff --stat -- api exp/api config/crd config/rbac config/webhook config/default > .pr-gate/generated-diff-stat.log
+            git diff --exit-code -- api exp/api config/crd config/rbac config/webhook config/default > .pr-gate/generated-diff.log 2>&1
+            diff_status=$?
+            if [ "${diff_status}" -eq 0 ]; then
+              printf 'generated API and manifests\tPASS\tGenerated artifacts are current\n' >> .pr-gate/results.tsv
+            else
+              touch .pr-gate/failed
+              printf 'generated API and manifests\tFAIL\tGenerated artifacts changed; see workflow logs\n' >> .pr-gate/results.tsv
+              echo "::group::generated API and manifests diff"
+              cat .pr-gate/generated-diff-stat.log
+              echo
+              sed -n '1,200p' .pr-gate/generated-diff.log
+              echo "::endgroup::"
+            fi
+          else
+            touch .pr-gate/failed
+            printf 'generated API and manifests\tFAIL\tSkipped diff because generation failed\n' >> .pr-gate/results.tsv
+          fi
+
+      - name: Check generated e2e templates
+        run: |
+          set +e
+
+          make generate-e2e-templates > .pr-gate/make-generate-e2e-templates.log 2>&1
+          template_status=$?
+
+          if [ "${template_status}" -ne 0 ]; then
+            touch .pr-gate/failed
+            printf 'make generate-e2e-templates\tFAIL\tExit code %s\n' "${template_status}" >> .pr-gate/results.tsv
+            echo "::group::make generate-e2e-templates output"
+            tail -n 120 .pr-gate/make-generate-e2e-templates.log
+            echo "::endgroup::"
+          else
+            printf 'make generate-e2e-templates\tPASS\tE2E template generation completed\n' >> .pr-gate/results.tsv
+            git diff --stat -- test/e2e/data/infrastructure-oci > .pr-gate/e2e-template-diff-stat.log
+            git diff --exit-code -- test/e2e/data/infrastructure-oci > .pr-gate/e2e-template-diff.log 2>&1
+            diff_status=$?
+            if [ "${diff_status}" -eq 0 ]; then
+              printf 'generated e2e templates\tPASS\tE2E templates are current\n' >> .pr-gate/results.tsv
+            else
+              touch .pr-gate/failed
+              printf 'generated e2e templates\tFAIL\tGenerated e2e templates changed; see workflow logs\n' >> .pr-gate/results.tsv
+              echo "::group::generated e2e templates diff"
+              cat .pr-gate/e2e-template-diff-stat.log
+              echo
+              sed -n '1,200p' .pr-gate/e2e-template-diff.log
+              echo "::endgroup::"
+            fi
+          fi
+
+      - name: Finalize report
+        id: final-report
+        if: ${{ always() }}
+        run: |
+          if [ ! -f .pr-gate/results.tsv ]; then
+            mkdir -p .pr-gate
+            printf 'Check\tResult\tDetails\n' > .pr-gate/results.tsv
+            printf 'workflow setup\tFAIL\tCheckout or setup failed before checks ran\n' >> .pr-gate/results.tsv
+            touch .pr-gate/failed
+          fi
+
+          {
+            echo "## PR Gate"
+            echo
+            echo "Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo
+            echo "| Check | Result | Details |"
+            echo "| --- | --- | --- |"
+            tail -n +2 .pr-gate/results.tsv | while IFS=$'\t' read -r check result details; do
+              printf '| `%s` | %s | %s |\n' "${check}" "${result}" "${details}"
+            done
+          } > .pr-gate/report.md
+
+          cat .pr-gate/report.md >> "${GITHUB_STEP_SUMMARY}"
+
+          if [ -f .pr-gate/failed ]; then
+            echo "result=failure" >> "${GITHUB_OUTPUT}"
+          else
+            echo "result=success" >> "${GITHUB_OUTPUT}"
+          fi
+
+          {
+            echo "report<<PR_GATE_REPORT_EOF"
+            cat .pr-gate/report.md
+            echo "PR_GATE_REPORT_EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+          if [ -f .pr-gate/failed ]; then
+            exit 1
+          fi
+
+  pr-comment:
+    name: PR comment
+    needs:
+      - local-checks
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Upsert PR gate comment
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          REPORT: ${{ needs.local-checks.outputs.report }}
+        run: |
+          marker='<!-- capoci-pr-gate-report -->'
+          body_file="${RUNNER_TEMP}/pr-gate-comment.md"
+          payload_file="${RUNNER_TEMP}/pr-gate-comment.json"
+
+          {
+            echo "${marker}"
+            if [ -n "${REPORT}" ]; then
+              printf '%s\n' "${REPORT}"
+            else
+              echo "## PR Gate"
+              echo
+              echo "PR gate did not produce a report. Check the workflow logs."
+            fi
+          } > "${body_file}"
+
+          jq -n --rawfile body "${body_file}" '{body: $body}' > "${payload_file}"
+
+          comment_id="$(
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+              --jq '.[] | select(.body | startswith("<!-- capoci-pr-gate-report -->")) | .id' |
+              head -n 1
+          )"
+
+          if [ -n "${comment_id}" ]; then
+            gh api --method PATCH "repos/${REPO}/issues/comments/${comment_id}" --input "${payload_file}"
+          else
+            gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input "${payload_file}"
+          fi

--- a/decision.md
+++ b/decision.md
@@ -1,0 +1,9 @@
+# Decisions
+
+## 2026-05-20: PR gate comments are best effort
+
+Context: The PR gate must execute pull request code to run local Makefile targets, and reviewers should get a PR-visible status summary when possible.
+
+Decision: Run local checks on the `pull_request` event with read-only repository permissions. Post the PR summary from a separate job that does not check out or execute pull request code, using an upserted issue comment marked with `<!-- capoci-pr-gate-report -->`.
+
+Consequences: Same-repository PRs can receive an updated summary comment. Fork PRs may only get the workflow check and job summary if GitHub restricts the token to read-only permissions. The workflow avoids `pull_request_target` for executing untrusted pull request code.

--- a/handoff.md
+++ b/handoff.md
@@ -1,0 +1,113 @@
+# PR Gate Workflow Handoff
+
+Date: 2026-05-22
+Branch: `add-pr-workflow`
+Current commit: `705fcaba6b96`
+
+## What Changed
+
+Added `.github/workflows/pr-gate.yaml`.
+
+The workflow runs on pull request events:
+
+- `opened`
+- `synchronize`
+- `reopened`
+- `ready_for_review`
+
+It runs the requested local-only checks:
+
+- `make build`
+- `make test`
+- `make generate`
+- `make manifests`
+- `make generate-e2e-templates`
+
+It also checks generated artifact freshness after generation:
+
+- `git diff --exit-code -- api exp/api config/crd config/rbac config/webhook config/default`
+- `git diff --exit-code -- test/e2e/data/infrastructure-oci`
+
+The workflow uses pinned actions:
+
+- `actions/checkout` pinned to `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (`v6.0.2`)
+- `actions/setup-go` pinned to `4a3601121dd01d1626a1e23e37211e3254c1c06c` (`v6.4.0`)
+
+Checkout uses `fetch-depth: 0` because `hack/version.sh` depends on git tags for version metadata.
+
+## PR Output
+
+The workflow writes a concise pass/fail table to the GitHub Actions job summary.
+
+It also tries to upsert a PR comment marked with:
+
+```text
+<!-- capoci-pr-gate-report -->
+```
+
+The comment job is best effort. It does not checkout or execute pull request code. It only reads the check job output and calls the GitHub API.
+
+For fork PRs, the checks should still run after maintainer approval, but the PR comment may not post because GitHub usually downgrades fork PR tokens to read-only. In that case, the job summary and workflow logs are the reliable output.
+
+## Security Model
+
+The workflow uses `pull_request`, not `pull_request_target`.
+
+That means pull request code is executed with read-only repository permissions. This is intentionally safer for fork PRs.
+
+The desired repo or org setting is to require maintainer approval before external fork workflows run. The approval policy should be:
+
+```text
+all_external_contributors
+```
+
+GitHub-side command if the maintainer has permission:
+
+```bash
+gh api \
+  --method PUT \
+  repos/oracle/cluster-api-provider-oci/actions/permissions/fork-pr-contributor-approval \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2026-03-10" \
+  -f approval_policy=all_external_contributors
+```
+
+Maintainers should review the fork PR diff first, then click **Approve workflows to run** in the PR checks area or on the waiting Actions run.
+
+## Documented But Not Implemented
+
+These additional local-only checks were identified but intentionally left out of the first workflow version:
+
+- `make lint`
+- `go mod tidy` followed by `git diff --exit-code -- go.mod go.sum`
+- `make build-book` for docs/book changes
+
+They are documented as comments in `.github/workflows/pr-gate.yaml`.
+
+## Validation Done
+
+Local validation completed:
+
+- YAML parsed successfully with Ruby's YAML parser.
+- `git diff --check` passed.
+- Dry-runs of the requested Make targets expanded successfully:
+  - `make -n build`
+  - `make -n test`
+  - `make -n generate`
+  - `make -n manifests`
+  - `make -n generate-e2e-templates`
+
+Full `make build`, `make test`, `make generate`, `make manifests`, and `make generate-e2e-templates` were not executed locally.
+
+## Files Added
+
+- `.github/workflows/pr-gate.yaml`
+- `decision.md`
+
+`decision.md` records why PR comments are best effort and why the workflow avoids `pull_request_target`.
+
+## Suggested Next Test
+
+Push the branch to a fork and open a PR from a branch in that fork back to the fork's `main` branch. That should test the workflow mechanics, Make steps, job summary, and possibly the PR comment.
+
+Testing the maintainer approval UX requires a fork PR into the upstream repository with the upstream approval policy enabled.


### PR DESCRIPTION
Test PR for the CAPOCI PR gate workflow. This should exercise .github/workflows/pr-gate.yaml on pull_request events in the fork before proposing it upstream.